### PR TITLE
카카오 로그인 구현

### DIFF
--- a/src/main/java/umc/kittenback/KittenBackApplication.java
+++ b/src/main/java/umc/kittenback/KittenBackApplication.java
@@ -15,4 +15,9 @@ public class KittenBackApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(KittenBackApplication.class, args);
 	}
+
+	@Bean
+	public BCryptPasswordEncoder encodePwd() {
+		return new BCryptPasswordEncoder();
+	}
 }

--- a/src/main/java/umc/kittenback/config/security/SecurityConfig.java
+++ b/src/main/java/umc/kittenback/config/security/SecurityConfig.java
@@ -1,6 +1,6 @@
 package umc.kittenback.config.security;
 
-import java.util.List;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +10,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import umc.kittenback.config.token.TokenProvider;
 import umc.kittenback.filter.JwtFilter;
 
@@ -23,26 +25,20 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .httpBasic().disable()
-                .formLogin().disable()
+                .cors()
+                .and()
+                .csrf().disable()
+
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
                 .and()
-                .cors().configurationSource(request -> {
-                    CorsConfiguration configuration = new CorsConfiguration();
-                    configuration.setAllowedOriginPatterns(List.of("*"));
-                    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                    configuration.setAllowedHeaders(List.of("*"));
-                    configuration.addExposedHeader("Authorization");
-                    return configuration;
-                })
-                .and()
-                .csrf().disable()
-
+                .formLogin().disable()
+                .httpBasic().disable()
                 .authorizeRequests()
                 // swagger 허용
-                .antMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                .antMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**").permitAll()
+                .antMatchers("/api/v1/kakao/**", "/kakao").permitAll()
                 .anyRequest().permitAll()
 
                 .and()
@@ -51,4 +47,15 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration().applyPermitDefaultValues();
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.addExposedHeader("Authorization");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }

--- a/src/main/java/umc/kittenback/config/swagger/SwaggerConfig.java
+++ b/src/main/java/umc/kittenback/config/swagger/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package umc.kittenback.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI UMCstudyAPI() {
+        Info info = new Info()
+                .title("UMC Server WorkBook API")
+                .description("UMC Server WorkBook API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/umc/kittenback/controller/UserController.java
+++ b/src/main/java/umc/kittenback/controller/UserController.java
@@ -1,0 +1,45 @@
+package umc.kittenback.controller;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.kittenback.config.token.TokenProvider;
+import umc.kittenback.dto.user.UserLoginResponseDto;
+import umc.kittenback.service.kakao.KakaoUserService;
+import umc.kittenback.service.user.UserServiceImpl;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final KakaoUserService kakaoUserService;
+    private final UserServiceImpl userService;
+    private final TokenProvider tokenProvider;
+
+
+    @GetMapping("/kakao")
+    public ResponseEntity<UserLoginResponseDto> kakaoLogin(@RequestParam("code")String code){
+        // Set Hedaer
+        HttpHeaders httpHeaders = new HttpHeaders();
+        String token = kakaoUserService.kakaoLogin(code);
+
+        httpHeaders.add("Authorization", "Bearer " + token);
+        UserLoginResponseDto loginResponseDto = userService.login(tokenProvider.getUserEmail(token));
+
+        return ResponseEntity.ok()
+                .headers(httpHeaders)
+                .body(loginResponseDto);
+    }
+
+    @GetMapping("/")
+    public String index() {
+        return "home";
+    }
+
+}

--- a/src/main/java/umc/kittenback/dto/kakao/KakaoAccessTokenResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/kakao/KakaoAccessTokenResponseDto.java
@@ -1,0 +1,19 @@
+package umc.kittenback.dto.kakao;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoAccessTokenResponseDto {
+
+    private String token_type;
+    private String access_token;
+    private String expires_in;
+    private String refresh_token;
+    private String refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/umc/kittenback/dto/kakao/KakaoAccountResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/kakao/KakaoAccountResponseDto.java
@@ -1,0 +1,15 @@
+package umc.kittenback.dto.kakao;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoAccountResponseDto {
+    private KakaoProfileResponseDto profile;
+    private String name;
+    private String email;
+}

--- a/src/main/java/umc/kittenback/dto/kakao/KakaoProfileResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/kakao/KakaoProfileResponseDto.java
@@ -1,0 +1,17 @@
+package umc.kittenback.dto.kakao;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoProfileResponseDto {
+
+    private String nickname;
+    private String thumbnail_image_url;
+    private String profile_image_url;
+    private boolean is_default_image;
+}

--- a/src/main/java/umc/kittenback/dto/kakao/KakaoProfileResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/kakao/KakaoProfileResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoProfileResponseDto {
 
+    private String email;
     private String nickname;
     private String thumbnail_image_url;
     private String profile_image_url;

--- a/src/main/java/umc/kittenback/dto/kakao/KakaoResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/kakao/KakaoResponseDto.java
@@ -1,0 +1,16 @@
+package umc.kittenback.dto.kakao;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoResponseDto<T> {
+    private Long id;
+    private LocalDateTime createDate;
+    private T kakao_account;
+}

--- a/src/main/java/umc/kittenback/dto/user/UserDetailResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/user/UserDetailResponseDto.java
@@ -1,0 +1,23 @@
+package umc.kittenback.dto.user;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.Pet;
+import umc.kittenback.domain.enums.OAuth2Provider;
+import umc.kittenback.domain.enums.UserRole;
+
+@Getter
+@Builder
+public class UserDetailResponseDto {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private UserRole userRole;
+    private OAuth2Provider provider;
+    private String providerId;
+    private String profileImage;
+    private Boolean hasPet;
+    private List<Pet> pets;
+}

--- a/src/main/java/umc/kittenback/dto/user/UserLoginResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/user/UserLoginResponseDto.java
@@ -1,0 +1,16 @@
+package umc.kittenback.dto.user;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.enums.UserRole;
+
+@Getter
+@Builder
+public class UserLoginResponseDto {
+
+    private final Long id;
+    private final String email;
+    private final UserRole role;
+    private final LocalDateTime createDate;
+}

--- a/src/main/java/umc/kittenback/filter/JwtFilter.java
+++ b/src/main/java/umc/kittenback/filter/JwtFilter.java
@@ -37,6 +37,8 @@ public class JwtFilter extends GenericFilterBean {
             logger.error("Security context에 설정되지 않음", e);
         }
 
+        chain.doFilter(request, response);
+
     }
 
     /*

--- a/src/main/java/umc/kittenback/service/kakao/KakaoUserService.java
+++ b/src/main/java/umc/kittenback/service/kakao/KakaoUserService.java
@@ -1,0 +1,166 @@
+package umc.kittenback.service.kakao;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import umc.kittenback.config.token.TokenProvider;
+import umc.kittenback.domain.User;
+import umc.kittenback.domain.enums.OAuth2Provider;
+import umc.kittenback.domain.enums.UserRole;
+import umc.kittenback.dto.kakao.KakaoAccessTokenResponseDto;
+import umc.kittenback.dto.kakao.KakaoAccountResponseDto;
+import umc.kittenback.dto.kakao.KakaoResponseDto;
+import umc.kittenback.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoUserService {
+
+    private final String KAKAO_TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
+    private final String KAKAO_PROFILE_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final UserRepository userRepository;
+
+    private final TokenProvider tokenProvider;
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${social.kakao.clientId}")
+    private String clientId;
+
+    @Value("${social.kakao.secret}")
+    private String secret;
+
+    @Value("${social.kakao.redirect}")
+    private String redirectUri;
+
+    /**
+     * 실제 카카오 로그인을 통해서 JWT 토큰을 발급하는 메소드
+     *
+     * @param code 카카오에서 주는 임시 코드
+     * @return JWT 토큰
+     */
+    public String kakaoLogin(String code) {
+        User user;
+
+        // 1. 카카오로부터 access_code로 받는다.
+        KakaoAccessTokenResponseDto tokenResponseDto = getAccessToken(code);
+
+        // 2. 카카오로부터 받은 access_code로 유저 프로필을 받아온다.
+        KakaoResponseDto<KakaoAccountResponseDto> kakaoResponseDto = getUserInfo(tokenResponseDto.getAccess_token());
+        KakaoAccountResponseDto profileResponseDto = kakaoResponseDto.getKakao_account();
+
+        // 3. 카카오 이메일로 부터 기존에 사용자가 있는지 조회한다.
+        Optional<User> optionalUser = userRepository.findByEmail(profileResponseDto.getEmail());
+
+        if (optionalUser.isPresent()) {
+            // 4-1. 사용자가 있으면 그 사용자를 가져온다.
+            user = optionalUser.get();
+        } else {
+
+            // 4-2. 사용자가 없으면 새로 회원가입을 진행한다.
+//            String password = bCryptPasswordEncoder.encode("tbookSecret"); // 임의의 패스워드
+            Long providerId = kakaoResponseDto.getId(); // 카카오 공급자 ID
+
+            // 4-2-1. 새로운 유저를 생성한다.
+            user = User.builder()
+                    .email(profileResponseDto.getEmail())
+                    .name(profileResponseDto.getProfile().getNickname())
+                    .nickname(profileResponseDto.getProfile().getNickname())
+                    .userRole(UserRole.ROLE_USER)
+                    .provider(OAuth2Provider.KAKAO)
+                    .providerId(providerId.toString())
+                    .profileImage(null)
+                    .hasPet(false)
+                    .pets(null)
+                    .build();
+
+            userRepository.save(user);
+        }
+
+        // 5. 만들어진 토큰을 반환한다.
+        return tokenProvider.createToken(user.getEmail(), user.getUserRole());
+    }
+
+    /**
+     * 카카오로 부터 access_code를 요청한다.
+     *
+     * @param code 카카오에서 부여하는 임시 코드
+     * @return access_code
+     */
+    public KakaoAccessTokenResponseDto getAccessToken(String code) {
+
+        // Set Header
+        // @WARNING MediaType.APPLICATION_FORM_URLENCODED를 설정하지 않으면 401 Authenticated 오류가 뜨니 주의
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("Accept", "application/json");
+
+        // Set Body
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", secret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        // Set http entity
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        // 액세스 코드를 받기 위한 파라미터 설정
+        // reference https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+        ResponseEntity<KakaoAccessTokenResponseDto> responseDto = restTemplate.postForEntity(KAKAO_TOKEN_REQUEST_URL, request,
+                KakaoAccessTokenResponseDto.class);
+
+        // 액세스 토큰 저장
+        return responseDto.getBody();
+    }
+
+    /**
+     * 발급된 access_token으로 유저 프로필 정보를 가져온다.
+     *
+     * @param accessToken
+     * @return 유저 프로필을 담은 GoogleProfileResponse 객체
+     */
+    public KakaoResponseDto<KakaoAccountResponseDto> getUserInfo(String accessToken) {
+
+        // 헤더에 accessToken을 넣는다.
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        // 카카오로 부터 유저 프로필 정보를 가져온다
+        // refrence https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        // 결과값을 KakaoResponseDto<KakaoAccountResponseDto> 객체에 넣어서 가져온다.
+        ResponseEntity<KakaoResponseDto<KakaoAccountResponseDto>> response = restTemplate.exchange(
+                KAKAO_PROFILE_REQUEST_URL,
+                HttpMethod.GET,
+                request,
+                new ParameterizedTypeReference<KakaoResponseDto<KakaoAccountResponseDto>>() {}
+        );
+
+        // 로그로 상태 코드와 응답 바디 출력
+        System.out.println("Response Status Code: " + response.getStatusCode());
+        System.out.println("Response Body: " + response.getBody());
+
+        if (response.getBody() != null) {
+            return response.getBody();
+        }
+
+        return null;
+
+    }
+}

--- a/src/main/java/umc/kittenback/service/user/UserService.java
+++ b/src/main/java/umc/kittenback/service/user/UserService.java
@@ -1,0 +1,11 @@
+package umc.kittenback.service.user;
+
+import umc.kittenback.dto.user.UserDetailResponseDto;
+import umc.kittenback.dto.user.UserLoginResponseDto;
+
+public interface UserService {
+
+    UserLoginResponseDto login(String email);
+
+    UserDetailResponseDto getUserDetail(String token);
+}

--- a/src/main/java/umc/kittenback/service/user/UserServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/user/UserServiceImpl.java
@@ -1,0 +1,55 @@
+package umc.kittenback.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.config.token.TokenProvider;
+import umc.kittenback.domain.User;
+import umc.kittenback.dto.user.UserDetailResponseDto;
+import umc.kittenback.dto.user.UserLoginResponseDto;
+import umc.kittenback.exception.handler.UserHandler;
+import umc.kittenback.repository.UserRepository;
+import umc.kittenback.response.code.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserLoginResponseDto login(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return UserLoginResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .role(user.getUserRole())
+                .createDate(user.getCreateDate())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetailResponseDto getUserDetail(String token) {
+        String email = tokenProvider.getUserEmail(token);
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return UserDetailResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .userRole(user.getUserRole())
+                .provider(user.getProvider())
+                .providerId(user.getProviderId())
+                .hasPet(user.getHasPet())
+                .pets(user.getPets())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     username: root
     password:
 
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
@@ -21,3 +25,10 @@ jwt:
   header: Authorization
   secret: 712f0bc8c7475fdc6e30bd3f81aaba2a7c5c648b398a70b2b53b1d0c63163f4f85de9fcf97da6cbd8742bf02fd4cd5090627ae80e6e5564c20064f264c5dbbf6
   duration: 30
+
+social:
+  kakao:
+    clientId: d3f3146fcef4a3b95c27cddd2e4782a2
+    secret: ddckOyrA0DVQwD39YzxifeRhVSkvXki0
+    redirect: http://localhost:8080/login/oauth2/kakao
+


### PR DESCRIPTION
## 카카오 로그인을 구현완료하였습니다.

## 발생 오류
- [x] security 적용 후 swagger, JwtFilter가 잘 적용되지 않았습니다.
- JwtFilter 에서 다음 Filter를 실행하는 doFilter 메서드 선언이 빠져있었습니다. doFilter 메서드를 선언하여 이를 해결하였습니다.

- [x] 카카오로부터 사용자의 이메일을 받아오지 못하는 오류가 발생하였습니다.
- 카카오 로그인 api에서 사용자의 이메일을 정상적으로 받아오기 위해 개인 비즈앱 전환 후 필수 항목으로 이메일을 받아오도록 하여 이를 해결하였습니다. 

