### PR TITLE
FEAT: MyPage 구현

### DIFF
--- a/src/main/java/umc/kittenback/controller/MyPageController.java
+++ b/src/main/java/umc/kittenback/controller/MyPageController.java
@@ -1,0 +1,71 @@
+package umc.kittenback.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.kittenback.dto.mypage.MyPageJoinResponseDto;
+import umc.kittenback.dto.mypage.MyPageRequestDto;
+import umc.kittenback.response.ApiResponse;
+import umc.kittenback.service.mypage.MyPageCommandServiceImpl;
+import umc.kittenback.service.mypage.MyPageQueryServiceImpl;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+
+    private final MyPageQueryServiceImpl MyPageQueryService;
+    private final MyPageCommandServiceImpl MyPageCommandService;
+
+    @GetMapping("/info/{id}")
+    @Operation(summary = "마이 페이지 접속 API", description = "마이 페이지 접속 시 보이는 정보에 대한 API입니다.")
+    @ApiResponses({@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON401", description = "인증이 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON403", description = "금지된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰 필요", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 이상", content = @Content(schema = @Schema(implementation = ApiResponse.class)))})
+    @Parameters({
+            @Parameter(name = "id", description = "UserId 값")
+    })
+    public ApiResponse<MyPageJoinResponseDto> getMyPageInfo(@PathVariable Long id) {
+        MyPageJoinResponseDto joinResponseDto = MyPageQueryService.getMyPageInfo(id);
+        return ApiResponse.onSuccess(joinResponseDto);
+    }
+
+    @PostMapping("/change/nickname")
+    @Operation(summary = "닉네임 변경 API", description = "닉네임 변경 시 사용되는 API입니다.")
+    public ResponseEntity<Boolean> changeNickname(@RequestBody MyPageRequestDto.ChangeNicknameDto req) {
+        return ResponseEntity.ok(MyPageCommandService.changeNickname(req));
+    }
+
+    @PostMapping("/change/hasPet")
+    @Operation(summary = "반려인 설정 변경 API", description = "반려인 설정 변경 시 사용되는 API입니다.")
+    public ResponseEntity<Boolean> changeHasPet(@RequestBody MyPageRequestDto.ChangeHasPetDto req) {
+        return ResponseEntity.ok(MyPageCommandService.changeHasPet(req));
+    }
+
+    @PostMapping("/change/profileImage")
+    @Operation(summary = "프로필 이미지 변경 API", description = "마이 페이지 접속 시 보이는 정보에 대한 API입니다.")
+    public ResponseEntity<Boolean> changeProfileImage(@RequestBody MyPageRequestDto.ChangeProfileImageDto req) {
+        return ResponseEntity.ok(MyPageCommandService.changeProfileImage(req));
+    }
+
+    // agreement 누락으로 보류 상태
+//    @PostMapping("/change/agreement")
+//    public ResponseEntity<Boolean> changeAgreement(@RequestBody MyPageRequestDto.ChangeAgreementDto req) {
+//        return ResponseEntity.ok(MyPageCommandService.changeAgreement(req));
+//    }
+}

--- a/src/main/java/umc/kittenback/domain/User.java
+++ b/src/main/java/umc/kittenback/domain/User.java
@@ -65,4 +65,12 @@ public class User extends BaseEntity{
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Pet> pets = new ArrayList<>();
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+    public void setHasPet(Boolean hasPet) {
+        this.hasPet = hasPet;
+    }
+    public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
 }

--- a/src/main/java/umc/kittenback/dto/mypage/MyPageJoinResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/mypage/MyPageJoinResponseDto.java
@@ -1,0 +1,16 @@
+package umc.kittenback.dto.mypage;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.Pet;
+
+@Getter
+@Builder
+public class MyPageJoinResponseDto {
+    private final Long id;
+    private final String nickname;
+    private final String profileImage;
+    private Boolean hasPet;
+    private List<Pet> pets;
+}

--- a/src/main/java/umc/kittenback/dto/mypage/MyPageRequestDto.java
+++ b/src/main/java/umc/kittenback/dto/mypage/MyPageRequestDto.java
@@ -1,0 +1,47 @@
+package umc.kittenback.dto.mypage;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+// 코드 스타일에 맞춰 분리해야 할 듯
+// 수정필요
+public class MyPageRequestDto {
+
+    @Getter
+    @Builder
+    public static class ChangeNicknameDto {
+        @NotBlank
+        Long id;
+        @NotBlank
+        String nickname;
+    }
+
+    @Getter
+    @Builder
+    public static class ChangeProfileImageDto {
+        @NotBlank
+        Long id;
+        @NotBlank
+        String profileImage;
+    }
+
+    @Getter
+    @Builder
+    public static class ChangeHasPetDto {
+        @NotBlank
+        Long id;
+        @NotBlank
+        Boolean hasPet;
+    }
+
+    // 현재 dto에서 agreement가 누락 되어 임시 보류
+//    @Getter
+//    @Builder
+//    public static class ChangeAgreementDto {
+//        @NotBlank
+//        Long id;
+//        @NotBlank
+//        Boolean agreement;
+//    }
+}

--- a/src/main/java/umc/kittenback/service/mypage/MyPageCommandService.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageCommandService.java
@@ -1,0 +1,12 @@
+package umc.kittenback.service.mypage;
+
+import umc.kittenback.dto.mypage.MyPageRequestDto;
+
+public interface MyPageCommandService {
+
+    Boolean changeNickname(MyPageRequestDto.ChangeNicknameDto req);
+    Boolean changeHasPet(MyPageRequestDto.ChangeHasPetDto req);
+    Boolean changeProfileImage(MyPageRequestDto.ChangeProfileImageDto req);
+//    Boolean changeAgreement(MyPageRequestDto.MyPageRequestDto req);
+
+}

--- a/src/main/java/umc/kittenback/service/mypage/MyPageCommandServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageCommandServiceImpl.java
@@ -1,0 +1,52 @@
+package umc.kittenback.service.mypage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.domain.User;
+import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeHasPetDto;
+import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeNicknameDto;
+import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeProfileImageDto;
+import umc.kittenback.exception.handler.UserHandler;
+import umc.kittenback.repository.UserRepository;
+import umc.kittenback.response.code.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageCommandServiceImpl implements MyPageCommandService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public Boolean changeNickname(ChangeNicknameDto req) {
+        User user = userRepository.findById(req.getId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+//                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다. id=" + id));
+        user.setNickname(req.getNickname());
+        userRepository.save(user);
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean changeHasPet(ChangeHasPetDto req) {
+        User user = userRepository.findById(req.getId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        //                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다. id=" + id));
+        user.setHasPet(req.getHasPet());
+        userRepository.save(user);
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean changeProfileImage(ChangeProfileImageDto req) {
+        User user = userRepository.findById(req.getId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        //                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다. id=" + id));
+        user.setProfileImage(req.getProfileImage());
+        userRepository.save(user);
+        return true;
+    }
+}

--- a/src/main/java/umc/kittenback/service/mypage/MyPageQueryService.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageQueryService.java
@@ -1,0 +1,7 @@
+package umc.kittenback.service.mypage;
+
+import umc.kittenback.dto.mypage.MyPageJoinResponseDto;
+
+public interface MyPageQueryService {
+    MyPageJoinResponseDto getMyPageInfo(Long id);
+}

--- a/src/main/java/umc/kittenback/service/mypage/MyPageQueryServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package umc.kittenback.service.mypage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.domain.User;
+import umc.kittenback.dto.mypage.MyPageJoinResponseDto;
+import umc.kittenback.exception.handler.UserHandler;
+import umc.kittenback.repository.UserRepository;
+import umc.kittenback.response.code.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageQueryServiceImpl implements MyPageQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MyPageJoinResponseDto getMyPageInfo(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+//                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다. id=" + id));
+
+        return MyPageJoinResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .hasPet(user.getHasPet())
+                .pets(user.getPets())
+                .build();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 마이페이지 조회 API
- 닉네임 변경 API
- 프로필사진 변경 API
- 반려인 설정 API
- 마케팅 수신동의 API(User에 수신동의 항목이 빠져있어 주석처리해둠)


## 남은 부분 및 목표
- swagger 세부사항 추가
- 응답 코드 관련 세부사항
- 예외 상황에 대한 처리 코드 추가

