### PR TITLE
FEAT: HealthNote API 구현 및 MyPage 마케팅 수신동의변경 API 구현

### DIFF
--- a/src/main/java/umc/kittenback/controller/HealthNoteController.java
+++ b/src/main/java/umc/kittenback/controller/HealthNoteController.java
@@ -42,7 +42,7 @@ public class HealthNoteController {
     // 건강수첩 작성 시 사용되는 API
     // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
     public ApiResponse<Boolean> writeHealthNote(@PathVariable Long id,
-                                                   @RequestBody writeHealthNoteDto req) {
+                                                @RequestBody writeHealthNoteDto req) {
         return ApiResponse.onSuccess(HealthNoteCommandService.writeHealthNote(id, req));
     }
 

--- a/src/main/java/umc/kittenback/controller/HealthNoteController.java
+++ b/src/main/java/umc/kittenback/controller/HealthNoteController.java
@@ -1,0 +1,72 @@
+package umc.kittenback.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.kittenback.domain.HealthNote;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.editHealthNoteDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.writeHealthNoteDto;
+import umc.kittenback.response.ApiResponse;
+import umc.kittenback.service.healthNote.HealthNoteCommandServiceImpl;
+import umc.kittenback.service.healthNote.HealthNoteQueryServiceImpl;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/healthNote")
+public class HealthNoteController {
+    private final HealthNoteQueryServiceImpl HealthNoteQueryService;
+    private final HealthNoteCommandServiceImpl HealthNoteCommandService;
+
+    @GetMapping("/Pets/{id}")
+    @Operation(summary = "건강수첩 접속 API", description = "건강수첩 접속 시 키우고 있는 애완동물 출력해주는 API")
+    // 건강수첩 접속 시 건강수첩을 보기 위해 선택해야할 애완동물들을 보여주는 API
+    // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
+    public ApiResponse<HealthNotePetsResponseDto> getHealthNotePetsInfo(@PathVariable Long id) {
+        HealthNotePetsResponseDto PetsResponseDto = HealthNoteQueryService.getHealthNotePetsInfo(id);
+        return ApiResponse.onSuccess(PetsResponseDto);
+    }
+
+    @PostMapping("/write/{id}")
+    @Operation(summary = "건강수첩 작성 API", description = "건강수첩 작성 시 사용되는 API.")
+    // 건강수첩 작성 시 사용되는 API
+    // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
+    public ApiResponse<Boolean> writeHealthNote(@PathVariable Long id,
+                                                   @RequestBody writeHealthNoteDto req) {
+        return ApiResponse.onSuccess(HealthNoteCommandService.writeHealthNote(id, req));
+    }
+
+    @PutMapping("/{userId}")
+    @Operation(summary = "건강수첩 수정 API", description = "건강수첩 수정 시 사용되는 API.")
+    // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
+    public ApiResponse<Boolean> editHealthNote(@PathVariable Long userId,
+                                               @RequestParam Long id,
+                                               @RequestBody editHealthNoteDto req) {
+        return ApiResponse.onSuccess(HealthNoteCommandService.editHealthNote(userId, id, req));
+    }
+
+    @DeleteMapping("/{userId}")
+    @Operation(summary = "건강수첩 삭제 API", description = "건강수첩 삭제 시 사용되는 API.")
+    // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
+    public ApiResponse<Boolean> deleteHealthNote(@PathVariable Long userId,
+                                                 @RequestParam Long id) {
+        return ApiResponse.onSuccess(HealthNoteCommandService.deleteHealthNote(userId, id));
+    }
+
+//    @GetMapping("/hospital")
+//    @Operation(summary = "건강수첩 병원 검색 API", description = "건강수첩 작성 중 병원 검색에 사용되는 API.")
+//    public ApiResponse<Boolean> searchHospital(@RequestParam String search) {
+//        return
+//    }
+
+}

--- a/src/main/java/umc/kittenback/controller/HealthNoteController.java
+++ b/src/main/java/umc/kittenback/controller/HealthNoteController.java
@@ -2,7 +2,6 @@ package umc.kittenback.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,10 +12,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import umc.kittenback.domain.HealthNote;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.editHealthNoteDto;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.writeHealthNoteDto;
+import umc.kittenback.dto.hospital.HospitalResponseDto;
 import umc.kittenback.response.ApiResponse;
 import umc.kittenback.service.healthNote.HealthNoteCommandServiceImpl;
 import umc.kittenback.service.healthNote.HealthNoteQueryServiceImpl;
@@ -63,10 +62,11 @@ public class HealthNoteController {
         return ApiResponse.onSuccess(HealthNoteCommandService.deleteHealthNote(userId, id));
     }
 
-//    @GetMapping("/hospital")
-//    @Operation(summary = "건강수첩 병원 검색 API", description = "건강수첩 작성 중 병원 검색에 사용되는 API.")
-//    public ApiResponse<Boolean> searchHospital(@RequestParam String search) {
-//        return
-//    }
+    @GetMapping("/hospital")
+    @Operation(summary = "건강수첩 병원 검색 API", description = "건강수첩 작성 중 병원 검색에 사용되는 API.")
+    public ApiResponse<HospitalResponseDto> searchHospital(@RequestParam String keyword) {
+        HospitalResponseDto hospitalResponseDto = HealthNoteQueryService.getHospitalSearchInfo(keyword);
+        return ApiResponse.onSuccess(hospitalResponseDto);
+    }
 
 }

--- a/src/main/java/umc/kittenback/controller/HealthNoteController.java
+++ b/src/main/java/umc/kittenback/controller/HealthNoteController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
-import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.editHealthNoteDto;
-import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.writeHealthNoteDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.EditHealthNoteDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto.WriteHealthNoteDto;
 import umc.kittenback.dto.hospital.HospitalResponseDto;
 import umc.kittenback.response.ApiResponse;
 import umc.kittenback.service.healthNote.HealthNoteCommandServiceImpl;
@@ -41,7 +41,7 @@ public class HealthNoteController {
     // 건강수첩 작성 시 사용되는 API
     // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
     public ApiResponse<Boolean> writeHealthNote(@PathVariable Long id,
-                                                @RequestBody writeHealthNoteDto req) {
+                                                @RequestBody WriteHealthNoteDto req) {
         return ApiResponse.onSuccess(HealthNoteCommandService.writeHealthNote(id, req));
     }
 
@@ -50,7 +50,7 @@ public class HealthNoteController {
     // Jwt에서 id값 추출 가능할 경우 Mapping 변경될 예정
     public ApiResponse<Boolean> editHealthNote(@PathVariable Long userId,
                                                @RequestParam Long id,
-                                               @RequestBody editHealthNoteDto req) {
+                                               @RequestBody EditHealthNoteDto req) {
         return ApiResponse.onSuccess(HealthNoteCommandService.editHealthNote(userId, id, req));
     }
 

--- a/src/main/java/umc/kittenback/controller/MyPageController.java
+++ b/src/main/java/umc/kittenback/controller/MyPageController.java
@@ -1,5 +1,6 @@
 package umc.kittenback.controller;
 
+import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -64,9 +65,8 @@ public class MyPageController {
         return ApiResponse.onSuccess(MyPageCommandService.changeProfileImage(req));
     }
 
-    // agreement 누락으로 보류 상태
-//    @PostMapping("/change/agreement")
-//    public ResponseEntity<Boolean> changeAgreement(@RequestBody MyPageRequestDto.ChangeAgreementDto req) {
-//        return ResponseEntity.ok(MyPageCommandService.changeAgreement(req));
-//    }
+    @PostMapping("/change/agreement")
+    public ApiResponse<UserDetailResponseDto> changeAgreement(@RequestBody MyPageRequestDto.ChangeAgreementDto req) {
+        return ApiResponse.onSuccess(MyPageCommandService.changeAgreement(req));
+    }
 }

--- a/src/main/java/umc/kittenback/domain/HealthNote.java
+++ b/src/main/java/umc/kittenback/domain/HealthNote.java
@@ -1,0 +1,54 @@
+package umc.kittenback.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.type.BigIntegerType;
+import umc.kittenback.domain.enums.HealthNoteType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class HealthNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
+
+    // 건강수첩 구분 - 예방접종, 건강수첩, 질병
+    @Enumerated(EnumType.STRING)
+    private HealthNoteType recordType;
+
+    // 건강수첩 제목
+    private String title;
+
+    //건강수첩 병원
+    private String hospital;
+
+    //건강수첩 날짜
+
+    //건강수첩 비용
+    private BigIntegerType cost;
+
+    //건강수첩 내용
+    private String content;
+
+
+}

--- a/src/main/java/umc/kittenback/domain/HealthNote.java
+++ b/src/main/java/umc/kittenback/domain/HealthNote.java
@@ -1,5 +1,9 @@
 package umc.kittenback.domain;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -9,16 +13,18 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.type.BigIntegerType;
+import lombok.Setter;
 import umc.kittenback.domain.enums.HealthNoteType;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -39,16 +45,19 @@ public class HealthNote {
     // 건강수첩 제목
     private String title;
 
+    // 건강수첩 기록 시간
+    private LocalDate date;
+
     //건강수첩 병원
     private String hospital;
 
-    //건강수첩 날짜
-
     //건강수첩 비용
-    private BigIntegerType cost;
+    private Integer cost;
 
     //건강수첩 내용
     private String content;
 
-
+    //건강수첩 이미지들
+    @OneToMany(mappedBy = "healthNote", cascade = CascadeType.ALL)
+    private List<HealthNoteImage> imageList = new ArrayList<>();
 }

--- a/src/main/java/umc/kittenback/domain/HealthNote.java
+++ b/src/main/java/umc/kittenback/domain/HealthNote.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import umc.kittenback.domain.common.BaseEntity;
 import umc.kittenback.domain.enums.HealthNoteType;
 
 @Entity
@@ -28,7 +29,7 @@ import umc.kittenback.domain.enums.HealthNoteType;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class HealthNote {
+public class HealthNote extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/kittenback/domain/HealthNoteImage.java
+++ b/src/main/java/umc/kittenback/domain/HealthNoteImage.java
@@ -1,0 +1,38 @@
+package umc.kittenback.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class HealthNoteImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "healthNote_id")
+    private HealthNote healthNote;
+
+    public HealthNoteImage(String imageUrl) {
+        this.image = imageUrl;
+    }
+}

--- a/src/main/java/umc/kittenback/domain/HealthNoteImage.java
+++ b/src/main/java/umc/kittenback/domain/HealthNoteImage.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import umc.kittenback.domain.common.BaseEntity;
 
 @Entity
 @Getter
@@ -20,7 +21,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class HealthNoteImage {
+public class HealthNoteImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/kittenback/domain/Hospital.java
+++ b/src/main/java/umc/kittenback/domain/Hospital.java
@@ -1,2 +1,33 @@
-package umc.kittenback.domain;public class Hospital {
+package umc.kittenback.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import umc.kittenback.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Hospital extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
 }

--- a/src/main/java/umc/kittenback/domain/Hospital.java
+++ b/src/main/java/umc/kittenback/domain/Hospital.java
@@ -1,0 +1,2 @@
+package umc.kittenback.domain;public class Hospital {
+}

--- a/src/main/java/umc/kittenback/domain/User.java
+++ b/src/main/java/umc/kittenback/domain/User.java
@@ -64,6 +64,9 @@ public class User extends BaseEntity {
     // 반려동물을 키우고 있는지 여부
     private Boolean hasPet;
 
+    // 마케팅 동의
+    private Boolean agreement;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Pet> pets = new ArrayList<>();
 
@@ -86,5 +89,5 @@ public class User extends BaseEntity {
         this.hasPet = hasPet;
     }
     public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
-
+    public void setAgreement(Boolean agreement) { this.agreement = agreement; }
 }

--- a/src/main/java/umc/kittenback/domain/enums/HealthNoteType.java
+++ b/src/main/java/umc/kittenback/domain/enums/HealthNoteType.java
@@ -1,0 +1,5 @@
+package umc.kittenback.domain.enums;
+
+public enum HealthNoteType {
+    VACCINATION, HEALTHNOTE, DISEASE
+}

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteListResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteListResponseDto.java
@@ -1,0 +1,33 @@
+package umc.kittenback.dto.checkIn.HealthNote;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.enums.HealthNoteType;
+
+@Getter
+@Builder
+public class HealthNoteListResponseDto {
+    // 건강수첩 기록 맞춰서 값 주기
+
+    public static class HealthNotePreviewDto {
+        Long id;
+        HealthNoteType type;
+        LocalDateTime dateTime;
+        String title;
+        String content;
+        String hospital;
+        BigInteger cost;
+    }
+
+    public static class HealthNotePreviewListDto {
+        List<HealthNotePreviewDto> healthNoteList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+}

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteListResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteListResponseDto.java
@@ -13,21 +13,21 @@ public class HealthNoteListResponseDto {
     // 건강수첩 기록 맞춰서 값 주기
 
     public static class HealthNotePreviewDto {
-        Long id;
-        HealthNoteType type;
-        LocalDateTime dateTime;
-        String title;
-        String content;
-        String hospital;
-        BigInteger cost;
+        private Long id;
+        private HealthNoteType type;
+        private LocalDateTime dateTime;
+        private String title;
+        private String content;
+        private String hospital;
+        private BigInteger cost;
     }
 
     public static class HealthNotePreviewListDto {
-        List<HealthNotePreviewDto> healthNoteList;
-        Integer listSize;
-        Integer totalPage;
-        Long totalElements;
-        Boolean isFirst;
-        Boolean isLast;
+        private List<HealthNotePreviewDto> healthNoteList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
     }
 }

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNotePetDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNotePetDto.java
@@ -1,0 +1,20 @@
+package umc.kittenback.dto.checkIn.HealthNote;
+
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.enums.PetGender;
+import umc.kittenback.domain.enums.PetType;
+
+
+// User의 애완동물 정보를 바로 가지고 올 경우 무한루프. 즉, 순환 참조가 발생하여 따로 PetDto로
+// 변환하여 애완동물 정보를 가져오기 위해 따로 생성
+@Getter
+@Builder
+public class HealthNotePetDto {
+    private Long id;
+    private PetType type;
+    private String name;
+    private String petProfileImage;
+    private PetGender gender;
+    private String notes;
+}

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNotePetsResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNotePetsResponseDto.java
@@ -1,0 +1,13 @@
+package umc.kittenback.dto.checkIn.HealthNote;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HealthNotePetsResponseDto {
+    private List<HealthNotePetDto> pets;
+}
+
+// User의 애완동물 정보를 바로 가지고 올 경우 무한루프. 즉, 순환 참조가 발생 -> PetDto

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
@@ -1,0 +1,37 @@
+package umc.kittenback.dto.checkIn.HealthNote;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import umc.kittenback.domain.HealthNoteImage;
+
+public class HealthNoteRequestDto {
+    @Getter
+    @Builder
+    public static class writeHealthNoteDto {
+        @NotBlank
+        String title;
+        String hospital;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+        LocalDate date;
+        Integer cost;
+        String content;
+//        List<String> images;
+    }
+
+    @Getter
+    @Builder
+    public static class editHealthNoteDto {
+        @NotBlank
+        String title;
+        String hospital;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+        LocalDate date;
+        Integer cost;
+        String content;
+//        List<String> images;
+    }
+}

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
@@ -7,11 +7,16 @@ import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import umc.kittenback.domain.HealthNoteImage;
+import umc.kittenback.domain.enums.HealthNoteType;
 
 public class HealthNoteRequestDto {
     @Getter
     @Builder
     public static class writeHealthNoteDto {
+        @NotBlank
+        Long petId;
+        @NotBlank
+        HealthNoteType recordType;
         @NotBlank
         String title;
         String hospital;
@@ -25,6 +30,10 @@ public class HealthNoteRequestDto {
     @Getter
     @Builder
     public static class editHealthNoteDto {
+        @NotBlank
+        Long petId;
+        @NotBlank
+        HealthNoteType recordType;
         @NotBlank
         String title;
         String hospital;

--- a/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
+++ b/src/main/java/umc/kittenback/dto/checkIn/HealthNote/HealthNoteRequestDto.java
@@ -1,46 +1,81 @@
 package umc.kittenback.dto.checkIn.HealthNote;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import umc.kittenback.domain.HealthNoteImage;
 import umc.kittenback.domain.enums.HealthNoteType;
 
 public class HealthNoteRequestDto {
-    @Getter
-    @Builder
-    public static class writeHealthNoteDto {
-        @NotBlank
-        Long petId;
-        @NotBlank
-        HealthNoteType recordType;
-        @NotBlank
-        String title;
+    @Data
+    public static class WriteHealthNoteDto {
+        @JsonProperty("petId")
+        private Long petId;
+        @JsonProperty("recordType")
+        private HealthNoteType recordType;
+        @JsonProperty("title")
+        private String title;
         String hospital;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate date;
         Integer cost;
         String content;
-//        List<String> images;
+        //List<String> images;
+
+        @JsonCreator
+        public WriteHealthNoteDto(@JsonProperty("petId") Long petId,
+                                  @JsonProperty("recordType") HealthNoteType recordType,
+                                  @JsonProperty("title") String title,
+                                  @JsonProperty("hospital") String hospital,
+                                  @JsonProperty("date") LocalDate date,
+                                  @JsonProperty("cost") Integer cost,
+                                  @JsonProperty("content") String content) {
+            this.petId = petId;
+            this.recordType = recordType;
+            this.title = title;
+            this.hospital = hospital;
+            this.date = date;
+            this.cost = cost;
+            this.content = content;
+        }
     }
 
-    @Getter
-    @Builder
-    public static class editHealthNoteDto {
-        @NotBlank
-        Long petId;
-        @NotBlank
-        HealthNoteType recordType;
-        @NotBlank
-        String title;
+    @Data
+    public static class EditHealthNoteDto {
+        @JsonProperty("petId")
+        private Long petId;
+        @JsonProperty("recordType")
+        private HealthNoteType recordType;
+        @JsonProperty("title")
+        private String title;
         String hospital;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate date;
         Integer cost;
         String content;
-//        List<String> images;
+        //List<String> images;
+
+        @JsonCreator
+        public EditHealthNoteDto(@JsonProperty("petId") Long petId,
+                                 @JsonProperty("recordType") HealthNoteType recordType,
+                                 @JsonProperty("title") String title,
+                                 @JsonProperty("hospital") String hospital,
+                                 @JsonProperty("date") LocalDate date,
+                                 @JsonProperty("cost") Integer cost,
+                                 @JsonProperty("content") String content) {
+            this.petId = petId;
+            this.recordType = recordType;
+            this.title = title;
+            this.hospital = hospital;
+            this.date = date;
+            this.cost = cost;
+            this.content = content;
+        }
     }
 }

--- a/src/main/java/umc/kittenback/dto/hospital/HospitalResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/hospital/HospitalResponseDto.java
@@ -1,9 +1,13 @@
 package umc.kittenback.dto.hospital;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import umc.kittenback.domain.Hospital;
 
 @Getter
 @Builder
-public class HospitalSearchDto {
+public class HospitalResponseDto {
+    private final Integer resultNum; // 검색된 병원 수
+    private List<Hospital> hospitals; // 병원 정보들
 }

--- a/src/main/java/umc/kittenback/dto/hospital/HospitalResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/hospital/HospitalResponseDto.java
@@ -1,0 +1,9 @@
+package umc.kittenback.dto.hospital;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HospitalSearchDto {
+}

--- a/src/main/java/umc/kittenback/dto/mypage/MyPageRequestDto.java
+++ b/src/main/java/umc/kittenback/dto/mypage/MyPageRequestDto.java
@@ -50,6 +50,19 @@ public class MyPageRequestDto {
         }
     }
 
+    @Data
+    public static class ChangeAgreementDto {
+        private Long id;
+        private Boolean agreement;
+
+        @JsonCreator
+        public ChangeAgreementDto(@JsonProperty("id") Long id,
+                                  @JsonProperty("agreement") Boolean agreement) {
+            this.id = id;
+            this.agreement = agreement;
+        }
+    }
+
 //    @Getter
 //    @Builder
 //    public static class ChangeNicknameDto {

--- a/src/main/java/umc/kittenback/dto/user/UserDetailResponseDto.java
+++ b/src/main/java/umc/kittenback/dto/user/UserDetailResponseDto.java
@@ -19,5 +19,6 @@ public class UserDetailResponseDto {
     private String providerId;
     private String profileImage;
     private Boolean hasPet;
+    private Boolean agreement;
     private List<Pet> pets;
 }

--- a/src/main/java/umc/kittenback/repository/HealthNoteRepository.java
+++ b/src/main/java/umc/kittenback/repository/HealthNoteRepository.java
@@ -1,0 +1,8 @@
+package umc.kittenback.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.kittenback.domain.HealthNote;
+
+public interface HealthNoteRepository extends JpaRepository<HealthNote, Long> {
+
+}

--- a/src/main/java/umc/kittenback/repository/HospitalRepository.java
+++ b/src/main/java/umc/kittenback/repository/HospitalRepository.java
@@ -1,0 +1,2 @@
+package umc.kittenback.repository;public interface HospitalRepository {
+}

--- a/src/main/java/umc/kittenback/repository/HospitalRepository.java
+++ b/src/main/java/umc/kittenback/repository/HospitalRepository.java
@@ -1,2 +1,9 @@
-package umc.kittenback.repository;public interface HospitalRepository {
+package umc.kittenback.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.kittenback.domain.Hospital;
+
+public interface HospitalRepository extends JpaRepository<Hospital, Long> {
+    List<Hospital> findByNameContainingOrAddressContaining(String name, String address);
 }

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandService.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandService.java
@@ -5,8 +5,8 @@ import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto;
 
 public interface HealthNoteCommandService {
-    Boolean writeHealthNote(Long id, HealthNoteRequestDto.writeHealthNoteDto req);
-    Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.editHealthNoteDto req);
+    Boolean writeHealthNote(Long id, HealthNoteRequestDto.WriteHealthNoteDto req);
+    Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.EditHealthNoteDto req);
 
     Boolean deleteHealthNote(Long userId, Long id);
 }

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandService.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandService.java
@@ -1,0 +1,12 @@
+package umc.kittenback.service.healthNote;
+
+import umc.kittenback.domain.HealthNote;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto;
+
+public interface HealthNoteCommandService {
+    Boolean writeHealthNote(Long id, HealthNoteRequestDto.writeHealthNoteDto req);
+    Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.editHealthNoteDto req);
+
+    Boolean deleteHealthNote(Long userId, Long id);
+}

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandServiceImpl.java
@@ -1,0 +1,74 @@
+package umc.kittenback.service.healthNote;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.domain.HealthNote;
+import umc.kittenback.domain.HealthNoteImage;
+import umc.kittenback.domain.User;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNoteRequestDto;
+import umc.kittenback.exception.handler.UserHandler;
+import umc.kittenback.repository.HealthNoteRepository;
+import umc.kittenback.repository.UserRepository;
+import umc.kittenback.response.code.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class HealthNoteCommandServiceImpl implements HealthNoteCommandService{
+
+    private final UserRepository userRepository;
+    private final HealthNoteRepository healthNoteRepository;
+
+    @Override
+    @Transactional
+    public Boolean writeHealthNote(Long id, HealthNoteRequestDto.writeHealthNoteDto req) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+//        List<HealthNoteImage> imageList = req.getImages().stream()
+//                .map(imageUrl -> new HealthNoteImage(imageUrl))
+//                .collect(Collectors.toList());
+        healthNoteRepository.save(HealthNote.builder()
+                .title(req.getTitle())
+                .hospital(req.getHospital())
+                .date(req.getDate())
+                .cost(req.getCost())
+                .content(req.getContent())
+//                .imageList(imageList)
+                .build()
+        );
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.editHealthNoteDto req) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+//        List<HealthNoteImage> imageList = req.getImages().stream()
+//                .map(imageUrl -> new HealthNoteImage(imageUrl))
+//                .collect(Collectors.toList());
+
+        healthNoteRepository.save(HealthNote.builder()
+                        .title(req.getTitle())
+                        .hospital(req.getHospital())
+                        .date(req.getDate())
+                        .cost(req.getCost())
+                        .content(req.getContent())
+//                .imageList(imageList)
+                        .build()
+        );
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean deleteHealthNote(Long userId, Long id){
+        HealthNote healthNote = healthNoteRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("ID 값을 찾을 수 없습니다."));
+        healthNoteRepository.delete(healthNote);
+
+        return true;
+    }
+}

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteCommandServiceImpl.java
@@ -26,7 +26,7 @@ public class HealthNoteCommandServiceImpl implements HealthNoteCommandService{
 
     @Override
     @Transactional
-    public Boolean writeHealthNote(Long id, HealthNoteRequestDto.writeHealthNoteDto req) {
+    public Boolean writeHealthNote(Long id, HealthNoteRequestDto.WriteHealthNoteDto req) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 //        List<HealthNoteImage> imageList = req.getImages().stream()
@@ -53,7 +53,7 @@ public class HealthNoteCommandServiceImpl implements HealthNoteCommandService{
 
     @Override
     @Transactional
-    public Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.editHealthNoteDto req) {
+    public Boolean editHealthNote(Long userId, Long id, HealthNoteRequestDto.EditHealthNoteDto req) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryService.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryService.java
@@ -1,7 +1,10 @@
 package umc.kittenback.service.healthNote;
 
 import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+import umc.kittenback.dto.hospital.HospitalResponseDto;
 
 public interface HealthNoteQueryService {
     HealthNotePetsResponseDto getHealthNotePetsInfo(Long id);
+
+    HospitalResponseDto getHospitalSearchInfo(String keyword);
 }

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryService.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryService.java
@@ -1,0 +1,7 @@
+package umc.kittenback.service.healthNote;
+
+import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+
+public interface HealthNoteQueryService {
+    HealthNotePetsResponseDto getHealthNotePetsInfo(Long id);
+}

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryServiceImpl.java
@@ -1,0 +1,44 @@
+package umc.kittenback.service.healthNote;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.domain.User;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetDto;
+import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+import umc.kittenback.exception.handler.UserHandler;
+import umc.kittenback.repository.HealthNoteRepository;
+import umc.kittenback.repository.UserRepository;
+import umc.kittenback.response.code.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class HealthNoteQueryServiceImpl implements HealthNoteQueryService {
+
+    private final UserRepository userRepository;
+    private final HealthNoteRepository healthNoteRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public HealthNotePetsResponseDto getHealthNotePetsInfo(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        List<HealthNotePetDto> petDtoList = user.getPets().stream()
+                .map(pet -> HealthNotePetDto.builder()
+                        .id(pet.getId())
+                        .type(pet.getType())
+                        .name(pet.getName())
+                        .petProfileImage(pet.getPetProfileImage())
+                        .gender(pet.getGender())
+                        .notes(pet.getNotes())
+                        .build())
+                .collect(Collectors.toList());
+
+        return HealthNotePetsResponseDto.builder()
+                .pets(petDtoList)
+                .build();
+    }
+}

--- a/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/healthNote/HealthNoteQueryServiceImpl.java
@@ -5,11 +5,14 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.kittenback.domain.Hospital;
 import umc.kittenback.domain.User;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetDto;
 import umc.kittenback.dto.checkIn.HealthNote.HealthNotePetsResponseDto;
+import umc.kittenback.dto.hospital.HospitalResponseDto;
 import umc.kittenback.exception.handler.UserHandler;
 import umc.kittenback.repository.HealthNoteRepository;
+import umc.kittenback.repository.HospitalRepository;
 import umc.kittenback.repository.UserRepository;
 import umc.kittenback.response.code.status.ErrorStatus;
 
@@ -19,6 +22,7 @@ public class HealthNoteQueryServiceImpl implements HealthNoteQueryService {
 
     private final UserRepository userRepository;
     private final HealthNoteRepository healthNoteRepository;
+    private final HospitalRepository hospitalRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -39,6 +43,17 @@ public class HealthNoteQueryServiceImpl implements HealthNoteQueryService {
 
         return HealthNotePetsResponseDto.builder()
                 .pets(petDtoList)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public HospitalResponseDto getHospitalSearchInfo(String keyword) {
+        List<Hospital> hospitals = hospitalRepository.findByNameContainingOrAddressContaining(keyword, keyword);
+
+        return HospitalResponseDto.builder()
+                .resultNum(hospitals.size())
+                .hospitals(hospitals)
                 .build();
     }
 }

--- a/src/main/java/umc/kittenback/service/mypage/MyPageCommandService.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageCommandService.java
@@ -8,6 +8,6 @@ public interface MyPageCommandService {
     UserDetailResponseDto changeNickname(MyPageRequestDto.ChangeNicknameDto req);
     UserDetailResponseDto changeHasPet(MyPageRequestDto.ChangeHasPetDto req);
     UserDetailResponseDto changeProfileImage(MyPageRequestDto.ChangeProfileImageDto req);
-//    Boolean changeAgreement(MyPageRequestDto.MyPageRequestDto req);
+    UserDetailResponseDto changeAgreement(MyPageRequestDto.ChangeAgreementDto req);
 
 }

--- a/src/main/java/umc/kittenback/service/mypage/MyPageCommandServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/mypage/MyPageCommandServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.kittenback.domain.User;
+import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeAgreementDto;
 import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeHasPetDto;
 import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeNicknameDto;
 import umc.kittenback.dto.mypage.MyPageRequestDto.ChangeProfileImageDto;
@@ -36,6 +37,7 @@ public class MyPageCommandServiceImpl implements MyPageCommandService {
                 .providerId(user.getProviderId())
                 .profileImage(user.getProfileImage())
                 .hasPet(user.getHasPet())
+                .agreement(user.getAgreement())
                 .pets(user.getPets())
                 .build();
     }
@@ -58,6 +60,7 @@ public class MyPageCommandServiceImpl implements MyPageCommandService {
                 .providerId(user.getProviderId())
                 .profileImage(user.getProfileImage())
                 .hasPet(user.getHasPet())
+                .agreement(user.getAgreement())
                 .pets(user.getPets())
                 .build();
     }
@@ -80,6 +83,29 @@ public class MyPageCommandServiceImpl implements MyPageCommandService {
                 .providerId(user.getProviderId())
                 .profileImage(user.getProfileImage())
                 .hasPet(user.getHasPet())
+                .agreement(user.getAgreement())
+                .pets(user.getPets())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public UserDetailResponseDto changeAgreement(ChangeAgreementDto req) {
+        User user = userRepository.findById(req.getId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        user.setAgreement(req.getAgreement());
+        userRepository.save(user);
+
+        return UserDetailResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .userRole(user.getUserRole())
+                .provider(user.getProvider())
+                .providerId(user.getProviderId())
+                .profileImage(user.getProfileImage())
+                .hasPet(user.getHasPet())
+                .agreement(user.getAgreement())
                 .pets(user.getPets())
                 .build();
     }

--- a/src/main/java/umc/kittenback/service/user/UserServiceImpl.java
+++ b/src/main/java/umc/kittenback/service/user/UserServiceImpl.java
@@ -48,6 +48,7 @@ public class UserServiceImpl implements UserService {
                 .userRole(user.getUserRole())
                 .provider(user.getProvider())
                 .providerId(user.getProviderId())
+                .agreement(user.getAgreement())
                 .hasPet(user.getHasPet())
                 .pets(user.getPets())
                 .build();


### PR DESCRIPTION
#19 에서 건강수첩, 마이페이지 부분 리팩토링 하고, 마케팅 수신동의변경 API 구현하여 
새롭게 PR 날립니다!

유의해야할 사항으로 도메인 User 엔티티에 새롭게 agreement가 추가 되었고,
UserDetailResponseDto와 UserServiceImpl에도 변경사항에 맞게 코드 변경해두었습니다.